### PR TITLE
Remove false positive warnings on during test restores

### DIFF
--- a/6.0/template_app_xenorchestra.yaml
+++ b/6.0/template_app_xenorchestra.yaml
@@ -427,7 +427,7 @@ zabbix_export:
             key: xoa.vms.raw
           triggers:
             - uuid: 90dd8a29cfc3457aabb35ce8527683d4
-              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.management.agent)="false"'
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.management.agent)="false" and {XCP-NG VM via Xen Orchestra:host.iregexp("^\[Importing")}=0'
               name: 'No management agent install on VM'
               priority: INFO
               manual_close: 'YES'
@@ -522,7 +522,7 @@ zabbix_export:
             key: xoa.vms.raw
           triggers:
             - uuid: 4f938791d96b4898860edf870a1bc72e
-              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state)<>last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state,#2)'
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state)<>last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state,#2) and {XCP-NG VM via Xen Orchestra:host.iregexp("^\[Importing")}=0'
               recovery_mode: NONE
               name: 'State of VM changed'
               priority: AVERAGE

--- a/6.0/template_app_xenorchestra.yaml
+++ b/6.0/template_app_xenorchestra.yaml
@@ -427,7 +427,7 @@ zabbix_export:
             key: xoa.vms.raw
           triggers:
             - uuid: 90dd8a29cfc3457aabb35ce8527683d4
-              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.management.agent)="false" and {XCP-NG VM via Xen Orchestra:host.iregexp("^\[Importing")}=0'
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.management.agent)="false" and {XCP-NG VM via Xen Orchestra:host.iregexp("^VM-\[Importing")}=0'
               name: 'No management agent install on VM'
               priority: INFO
               manual_close: 'YES'
@@ -522,7 +522,7 @@ zabbix_export:
             key: xoa.vms.raw
           triggers:
             - uuid: 4f938791d96b4898860edf870a1bc72e
-              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state)<>last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state,#2) and {XCP-NG VM via Xen Orchestra:host.iregexp("^\[Importing")}=0'
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state)<>last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state,#2) and {XCP-NG VM via Xen Orchestra:host.iregexp("^VM-\[Importing")}=0'
               recovery_mode: NONE
               name: 'State of VM changed'
               priority: AVERAGE

--- a/6.4/template_app_xenorchestra.yaml
+++ b/6.4/template_app_xenorchestra.yaml
@@ -427,7 +427,7 @@ zabbix_export:
             key: xoa.vms.raw
           triggers:
             - uuid: 90dd8a29cfc3457aabb35ce8527683d4
-              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.management.agent)="false"'
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.management.agent)="false" and {XCP-NG VM via Xen Orchestra:host.iregexp("^\[Importing")}=0'
               name: 'No management agent install on VM'
               priority: INFO
               manual_close: 'YES'
@@ -522,7 +522,7 @@ zabbix_export:
             key: xoa.vms.raw
           triggers:
             - uuid: 4f938791d96b4898860edf870a1bc72e
-              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state)<>last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state,#2)'
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state)<>last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state,#2) and {XCP-NG VM via Xen Orchestra:host.iregexp("^\[Importing")}=0'
               recovery_mode: NONE
               name: 'State of VM changed'
               priority: AVERAGE

--- a/6.4/template_app_xenorchestra.yaml
+++ b/6.4/template_app_xenorchestra.yaml
@@ -427,7 +427,7 @@ zabbix_export:
             key: xoa.vms.raw
           triggers:
             - uuid: 90dd8a29cfc3457aabb35ce8527683d4
-              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.management.agent)="false" and {XCP-NG VM via Xen Orchestra:host.iregexp("^\[Importing")}=0'
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.management.agent)="false" and {XCP-NG VM via Xen Orchestra:host.iregexp("^VM-\[Importing")}=0'
               name: 'No management agent install on VM'
               priority: INFO
               manual_close: 'YES'
@@ -522,7 +522,7 @@ zabbix_export:
             key: xoa.vms.raw
           triggers:
             - uuid: 4f938791d96b4898860edf870a1bc72e
-              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state)<>last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state,#2) and {XCP-NG VM via Xen Orchestra:host.iregexp("^\[Importing")}=0'
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state)<>last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state,#2) and {XCP-NG VM via Xen Orchestra:host.iregexp("^VM-\[Importing")}=0'
               recovery_mode: NONE
               name: 'State of VM changed'
               priority: AVERAGE

--- a/7.0/template_app_xenorchestra.yaml
+++ b/7.0/template_app_xenorchestra.yaml
@@ -452,7 +452,7 @@ zabbix_export:
             key: xoa.vms.raw
           triggers:
             - uuid: 90dd8a29cfc3457aabb35ce8527683d4
-              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.management.agent)="false"'
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.management.agent)="false" and {XCP-NG VM via Xen Orchestra:host.iregexp("^\[Importing")}=0'
               name: 'No management agent install on VM'
               priority: INFO
               manual_close: 'YES'
@@ -553,7 +553,7 @@ zabbix_export:
             key: xoa.vms.raw
           triggers:
             - uuid: 4f938791d96b4898860edf870a1bc72e
-              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state)<>last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state,#2)'
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state)<>last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state,#2) and {XCP-NG VM via Xen Orchestra:host.iregexp("^\[Importing")}=0'
               recovery_mode: NONE
               name: 'State of VM changed'
               priority: AVERAGE

--- a/7.0/template_app_xenorchestra.yaml
+++ b/7.0/template_app_xenorchestra.yaml
@@ -452,7 +452,7 @@ zabbix_export:
             key: xoa.vms.raw
           triggers:
             - uuid: 90dd8a29cfc3457aabb35ce8527683d4
-              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.management.agent)="false" and {XCP-NG VM via Xen Orchestra:host.iregexp("^\[Importing")}=0'
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.management.agent)="false" and {XCP-NG VM via Xen Orchestra:host.iregexp("^VM-\[Importing")}=0'
               name: 'No management agent install on VM'
               priority: INFO
               manual_close: 'YES'
@@ -553,7 +553,7 @@ zabbix_export:
             key: xoa.vms.raw
           triggers:
             - uuid: 4f938791d96b4898860edf870a1bc72e
-              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state)<>last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state,#2) and {XCP-NG VM via Xen Orchestra:host.iregexp("^\[Importing")}=0'
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state)<>last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state,#2) and {XCP-NG VM via Xen Orchestra:host.iregexp("^VM-\[Importing")}=0'
               recovery_mode: NONE
               name: 'State of VM changed'
               priority: AVERAGE

--- a/Readme.md
+++ b/Readme.md
@@ -17,13 +17,14 @@ This template has been tested on:
 - XenOrchestra CE
 - Zabbix 6.0
 - Zabbix 6.4
+- Zabbix 7.2.4
 
 !! ATTENTION !!
 
 Due to the [issue](https://support.zabbix.com/browse/ZBX-24926) with Zabbix 7.0 
 make sure to have the right cURL version installed. 
 
-The container for zabbix 7.0.4 seems to be working ok.
+The container for Zabbix 7.2.4 seems to be working ok.
 
 ## Author
 


### PR DESCRIPTION

To ensure the following false positive warnings do not occur during the test restore of VMs via Xen Orchestra:

No management agent install on VM
State of VM changed

(Ignore these states for hosts ^[Importing...] *) 