### PR TITLE
Exclude Health-Check and Continuous Replication VMs from discovery

### DIFF
--- a/6.0/template_app_xenorchestra.yaml
+++ b/6.0/template_app_xenorchestra.yaml
@@ -1602,8 +1602,8 @@ zabbix_export:
           value: CHANGE
           description: 'URL where XOA can be reached'
         - macro: '{$XOA.VM.IGNORE}'
-          value: '.*\[Importing.*'
-          description: 'Ignore VMs containing sting'
+          value: '^(.*\[Importing.*|VM-Health Check - .*|.* - \([0-9]{8}T[0-9]{6}Z\))$'
+          description: 'Excludes importing, health check, and Continuous Replication VMs'
       valuemaps:
         - uuid: 0ec95555cba645f796a21bdece34349c
           name: 'XOA Boolean'

--- a/7.0/template_app_xenorchestra.yaml
+++ b/7.0/template_app_xenorchestra.yaml
@@ -1687,7 +1687,7 @@ zabbix_export:
           value: CHANGE
           description: 'URL where XOA can be reached'
         - macro: '{$XOA.VM.IGNORE}'
-          value: '.*\[Importing.*'
+          value: '^(.*\[Importing.*|VM-Health Check - .*|.* - \([0-9]{8}T[0-9]{6}Z\))$'
           description: 'Do not discover VMs containing Strings included in this regexp'
       valuemaps:
         - uuid: 0ec95555cba645f796a21bdece34349c

--- a/7.0/template_app_xenorchestra.yaml
+++ b/7.0/template_app_xenorchestra.yaml
@@ -1688,7 +1688,7 @@ zabbix_export:
           description: 'URL where XOA can be reached'
         - macro: '{$XOA.VM.IGNORE}'
           value: '^(.*\[Importing.*|VM-Health Check - .*|.* - \([0-9]{8}T[0-9]{6}Z\))$'
-          description: 'Do not discover VMs containing Strings included in this regexp'
+          description: 'Excludes importing, health check, and Continuous Replication VMs'
       valuemaps:
         - uuid: 0ec95555cba645f796a21bdece34349c
           name: 'XOA Boolean'


### PR DESCRIPTION
Hi @bufanda,
Small PR to expand regex XOA.VM.IGNORE to ignore Health-Check VM and Continuous Replication VMs based on timestamp suffix.

Tested on Zabbix 7.0.
Manually implemented in template 6.0 but not tested.

Cheers,
Guillaume